### PR TITLE
Handle optional query params

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -228,7 +228,10 @@ app.util.normalizeSearchQuery = function(data) {
 
 app.util.cleanPropertyQuery = function(query) {
   // Trim, remove extra speces, and replace dots and hashes -- API can't handle them
-  return query.replace(/\./g, ' ').replace(/ {2,}/g, ' ').replace(/#/g, '').trim();
+  if (query) {
+    return query.replace(/\./g, ' ').replace(/ {2,}/g, ' ').replace(/#/g, '').trim();
+  }
+  return query;
 };
 
 // Pull a human-readable sales date from what the OPA API gives us


### PR DESCRIPTION
If an `undefined` param is passed to `cleanPropertyQuery` (e.g. for unit number), don't try clean it up.

Closes #102 
