### PR TITLE
Updates feedback link

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
     <!-- Begin Footer -->
     <div class="row feedback">
       <div class="small-24 columns">
-        <div class="panel center mbl"><p>We're still working on this page's design and content. <a href="/feedback/?url=alpha.phila.gov/property/">How can we make it better?</a></p></div>
+        <div class="panel center mbl"><p>We're still working on this page's design and content. <a href="http://alpha.phila.gov/feedback/">How can we make it better?</a></p></div>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 
     <link rel="stylesheet" href="//js.arcgis.com/3.15/esri/css/esri.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="//cityofphiladelphia.github.io/patterns/dist/1.1.3/css/patterns.css">
+    <link rel="stylesheet" href="//cityofphiladelphia.github.io/patterns/dist/1.1.5/css/patterns.css">
     <link rel="stylesheet" href="css/style.css">
     <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
   </head>
@@ -610,7 +610,7 @@
 
     <script src="//code.jquery.com/jquery-2.2.1.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/6.1.2/foundation.min.js"></script>
-    <script src="//cityofphiladelphia.github.io/patterns/dist/1.1.3/js/patterns.min.js"></script>
+    <script src="//cityofphiladelphia.github.io/patterns/dist/1.1.5/js/patterns.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/accounting.js/0.4.1/accounting.min.js"></script>
     <script src="//js.arcgis.com/3.15/"></script>
     <script src="//maps.googleapis.com/maps/api/js?v=3&libraries=geometry"></script>


### PR DESCRIPTION
Version 1.1.5 of Patterns removes the need for the hardcoded url parameter on the feedback link.
