### PR TITLE
Add loading spinners

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -147,6 +147,10 @@ body {
   width: 100%;
 }
 
+.hidden {
+  display: none;
+}
+
 @media only screen and (max-width: 40em) {
   .front .callout {
     margin:0.625rem 0 1rem 0;

--- a/css/style.css
+++ b/css/style.css
@@ -147,10 +147,6 @@ body {
   width: 100%;
 }
 
-.hidden {
-  display: none;
-}
-
 @media only screen and (max-width: 40em) {
   .front .callout {
     margin:0.625rem 0 1rem 0;

--- a/index.html
+++ b/index.html
@@ -406,7 +406,8 @@
             <h2 class="alternate divide">Valuation History</h2>
           </div>
         </div>
-        <div class="row">
+        <div data-hook="valuation-status"><i class="fa fa-spinner fa-lg spin"></i> Loading...</div>
+        <div data-hook="valuation-panel" class="row hidden">
           <div class="columns">
             <table role="grid" summary="Property valuation history." class="tablesaw tablesaw-stack" data-tablesaw-mode="stack">
               <thead>
@@ -467,7 +468,8 @@
             <h2 class="alternate divide">Trash &amp; Recycling</h2>
           </div>
         </div>
-        <div class="row">
+        <div data-hook="trash-status"><i class="fa fa-spinner fa-lg spin"></i> Loading...</div>
+        <div data-hook="trash-panel" class="row hidden">
           <div class="columns">
             <div class="panel sales mbm">
               <div class="row">
@@ -489,123 +491,126 @@
             <h2 class="alternate divide">Service Area</h2>
           </div>
         </div>
-        <div class="row">
-          <div class="medium-12 columns">
-            <div class="panel mbm">
-              <h3>School Catchment</h3>
-              <h4 class="alternate">Elementary School</h4>
-              <strong data-hook="elementary-school"></strong>
-              <h4 class="alternate">Middle School</h4>
-              <strong data-hook="middle-school"></strong>
-              <h4 class="alternate">High School</h4>
-              <strong data-hook="high-school"></strong>
-            </div>
-          </div>
-          <div class="medium-12 columns">
-            <div class="panel mbm">
-              <h3>Political</h3>
-              <h4 class="alternate">2016 Councilmanic District</h4>
-              <strong data-hook="council-district"></strong>
-              <h4 class="alternate">Ward</h4>
-              <strong data-hook="ward"></strong>
-              <h4 class="alternate">Ward Divisions</h4>
-              <strong data-hook="ward-divisions"></strong>
-            </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="columns">
-            <div class="panel mbm">
-              <div class="row">
-                <div class="columns">
-                  <h3>Public Safety</h3>
-                </div>
+        <div data-hook="service-area-status"><i class="fa fa-spinner fa-lg spin"></i> Loading...</div>
+        <div data-hook="service-area-panel" class="hidden">
+          <div class="row">
+            <div class="medium-12 columns">
+              <div class="panel mbm">
+                <h3>School Catchment</h3>
+                <h4 class="alternate">Elementary School</h4>
+                <strong data-hook="elementary-school"></strong>
+                <h4 class="alternate">Middle School</h4>
+                <strong data-hook="middle-school"></strong>
+                <h4 class="alternate">High School</h4>
+                <strong data-hook="high-school"></strong>
               </div>
-              <div class="row">
-                <div class="medium-12 columns">
-                  <h4 class="alternate">Police District</h4>
-                  <strong data-hook="police-district"></strong>
-
-                  <h4 class="alternate">Police Sector</h4>
-                  <strong data-hook="police-sector"></strong>
-                </div>
-                <div class="medium-12 columns">
-                  <h4 class="alternate">Police Public Service Area</h4>
-                  <strong data-hook="police-psa"></strong>
-
-                  <h4 class="alternate">Police Division</h4>
-                  <strong data-hook="police-division"></strong>
-                </div>
+            </div>
+            <div class="medium-12 columns">
+              <div class="panel mbm">
+                <h3>Political</h3>
+                <h4 class="alternate">2016 Councilmanic District</h4>
+                <strong data-hook="council-district"></strong>
+                <h4 class="alternate">Ward</h4>
+                <strong data-hook="ward"></strong>
+                <h4 class="alternate">Ward Divisions</h4>
+                <strong data-hook="ward-divisions"></strong>
               </div>
             </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="columns">
-            <div class="panel mbm">
-              <div class="row">
-                <div class="columns">
-                  <h3>Streets</h3>
+          <div class="row">
+            <div class="columns">
+              <div class="panel mbm">
+                <div class="row">
+                  <div class="columns">
+                    <h3>Public Safety</h3>
+                  </div>
                 </div>
-              </div>
-              <div class="row">
-                <div class="medium-12 columns">
-                  <h4 class="alternate">Highway District</h4>
-                  <strong data-hook="highway-district"></strong>
-                  <h4 class="alternate">Highway Section</h4>
-                  <strong data-hook="highway-section"></strong>
-                  <h4 class="alternate">Highway Subsection</h4>
-                  <strong data-hook="highway-subsection"></strong>
-                  <h4 class="alternate">Street Light Routes</h4>
-                  <strong data-hook="street-light-routes"></strong>
-                  <h4 class="alternate">Traffic District</h4>
-                  <strong data-hook="traffic-district"></strong>
-                  <h4 class="alternate">Traffic PM District</h4>
-                  <strong data-hook="traffic-pm-district"></strong>
-                </div>
-                <div class="medium-12 columns">
-                  <h4 class="alternate">Trash &amp; Recycling Day</h4>
-                  <strong data-hook="rubbish-day"></strong>
-                  <h4 class="alternate">Leaf Collection Day</h4>
-                  <strong data-hook="leaf-collection"></strong>
-                  <strong data-hook="" class="h1 stat no-margin"></strong>
-                  <h4 class="alternate">Recycling Diversion Rate</h4>
-                  <strong data-hook="recycling-diversion"></strong>
-                  <h4 class="alternate">Sanitation Area</h4>
-                  <strong data-hook="sanitation-area"></strong>
-                  <h4 class="alternate">Sanitation District</h4>
-                  <strong data-hook="sanitation-district"></strong>
+                <div class="row">
+                  <div class="medium-12 columns">
+                    <h4 class="alternate">Police District</h4>
+                    <strong data-hook="police-district"></strong>
+  
+                    <h4 class="alternate">Police Sector</h4>
+                    <strong data-hook="police-sector"></strong>
+                  </div>
+                  <div class="medium-12 columns">
+                    <h4 class="alternate">Police Public Service Area</h4>
+                    <strong data-hook="police-psa"></strong>
+  
+                    <h4 class="alternate">Police Division</h4>
+                    <strong data-hook="police-division"></strong>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="medium-12 columns">
-            <div class="panel mbm">
-              <h3>Districts</h3>
-              <h4 class="alternate">Planning</h4>
-              <strong data-hook="planning"></strong>
-              <h4 class="alternate">Licenses and Inspections (L+I)</h4>
-              <strong data-hook="li-district"></strong>
-              <h4 class="alternate">Recreation</h4>
-              <strong data-hook="recreation"></strong>
+          <div class="row">
+            <div class="columns">
+              <div class="panel mbm">
+                <div class="row">
+                  <div class="columns">
+                    <h3>Streets</h3>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="medium-12 columns">
+                    <h4 class="alternate">Highway District</h4>
+                    <strong data-hook="highway-district"></strong>
+                    <h4 class="alternate">Highway Section</h4>
+                    <strong data-hook="highway-section"></strong>
+                    <h4 class="alternate">Highway Subsection</h4>
+                    <strong data-hook="highway-subsection"></strong>
+                    <h4 class="alternate">Street Light Routes</h4>
+                    <strong data-hook="street-light-routes"></strong>
+                    <h4 class="alternate">Traffic District</h4>
+                    <strong data-hook="traffic-district"></strong>
+                    <h4 class="alternate">Traffic PM District</h4>
+                    <strong data-hook="traffic-pm-district"></strong>
+                  </div>
+                  <div class="medium-12 columns">
+                    <h4 class="alternate">Trash &amp; Recycling Day</h4>
+                    <strong data-hook="rubbish-day"></strong>
+                    <h4 class="alternate">Leaf Collection Day</h4>
+                    <strong data-hook="leaf-collection"></strong>
+                    <strong data-hook="" class="h1 stat no-margin"></strong>
+                    <h4 class="alternate">Recycling Diversion Rate</h4>
+                    <strong data-hook="recycling-diversion"></strong>
+                    <h4 class="alternate">Sanitation Area</h4>
+                    <strong data-hook="sanitation-area"></strong>
+                    <h4 class="alternate">Sanitation District</h4>
+                    <strong data-hook="sanitation-district"></strong>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
-          <div class="medium-12 columns">
-            <div class="panel mbm">
-              <h3>Water</h3>
-              <h4 class="alternate">PWD Maintenance Districts</h4>
-              <strong data-hook="pwd-maintenance"></strong>
-              <h4 class="alternate">PWD Pressure Districts</h4>
-              <strong data-hook="pwd-pressure"></strong>
-              <h4 class="alternate">Water Treatment Plant</h4>
-              <strong data-hook="water-treatment"></strong>
-              <h4 class="alternate">Water Plate Index</h4>
-              <strong data-hook="water-plate"></strong>
+          <div class="row">
+            <div class="medium-12 columns">
+              <div class="panel mbm">
+                <h3>Districts</h3>
+                <h4 class="alternate">Planning</h4>
+                <strong data-hook="planning"></strong>
+                <h4 class="alternate">Licenses and Inspections (L+I)</h4>
+                <strong data-hook="li-district"></strong>
+                <h4 class="alternate">Recreation</h4>
+                <strong data-hook="recreation"></strong>
+              </div>
+            </div>
+            <div class="medium-12 columns">
+              <div class="panel mbm">
+                <h3>Water</h3>
+                <h4 class="alternate">PWD Maintenance Districts</h4>
+                <strong data-hook="pwd-maintenance"></strong>
+                <h4 class="alternate">PWD Pressure Districts</h4>
+                <strong data-hook="pwd-pressure"></strong>
+                <h4 class="alternate">Water Treatment Plant</h4>
+                <strong data-hook="water-treatment"></strong>
+                <h4 class="alternate">Water Plate Index</h4>
+                <strong data-hook="water-plate"></strong>
+              </div>
             </div>
           </div>
-        </div> <!-- End service area -->
+        </div><!-- End service area panel -->
       </div><!-- End secondary content area -->
     </div> <!-- End templates -->
 

--- a/index.html
+++ b/index.html
@@ -407,7 +407,7 @@
           </div>
         </div>
         <div data-hook="valuation-status"><i class="fa fa-spinner fa-lg spin"></i> Loading...</div>
-        <div data-hook="valuation-panel" class="row hidden">
+        <div data-hook="valuation-panel" class="row hide">
           <div class="columns">
             <table role="grid" summary="Property valuation history." class="tablesaw tablesaw-stack" data-tablesaw-mode="stack">
               <thead>
@@ -469,7 +469,7 @@
           </div>
         </div>
         <div data-hook="trash-status"><i class="fa fa-spinner fa-lg spin"></i> Loading...</div>
-        <div data-hook="trash-panel" class="row hidden">
+        <div data-hook="trash-panel" class="row hide">
           <div class="columns">
             <div class="panel sales mbm">
               <div class="row">
@@ -492,7 +492,7 @@
           </div>
         </div>
         <div data-hook="service-area-status"><i class="fa fa-spinner fa-lg spin"></i> Loading...</div>
-        <div data-hook="service-area-panel" class="hidden">
+        <div data-hook="service-area-panel" class="hide">
           <div class="row">
             <div class="medium-12 columns">
               <div class="panel mbm">

--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@
             </div>
             <div class="medium-14 columns">
               <h4 class="alternate">Homestead Exemption</h4>
-              <strong data-hook="homestead">Yes</strong>
+              <strong data-hook="homestead"></strong>
             </div>
           </div>
           <div class="row">

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -20,7 +20,15 @@ app.views.property = function (accountNumber) {
   // Clear existing elements out of the way
   app.hooks.content.children().detach();
   app.hooks.aboveContent.children().detach();
-
+  
+  // Toggle loading messages, content panels
+  app.hooks.valuationStatus.removeClass('hide');
+  app.hooks.trashStatus.removeClass('hide');
+  app.hooks.serviceAreaStatus.removeClass('hide');
+  app.hooks.valuationPanel.addClass('hide');
+  app.hooks.trashPanel.addClass('hide');
+  app.hooks.serviceAreaPanel.addClass('hide');
+  
   if (!history.state) history.replaceState({}, '');
 
   if (history.state.error) return renderError();

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -313,8 +313,8 @@ app.views.property = function (accountNumber) {
     $(document).trigger('enhance.tablesaw');
     
     // Hide status, show content.
-    app.hooks.valuationStatus.hide();
-    app.hooks.valuationPanel.show();
+    app.hooks.valuationStatus.addClass('hide');
+    app.hooks.valuationPanel.removeClass('hide');
   }
 
   function getExteriorConditionDescription(id) {
@@ -397,10 +397,10 @@ app.views.property = function (accountNumber) {
     app.hooks.waterPlate.text(sa.water_plate);
     
     // Hide status messages, load content.
-    app.hooks.serviceAreaStatus.hide();
-    app.hooks.serviceAreaPanel.show();
-    app.hooks.trashStatus.hide();
-    app.hooks.trashPanel.show();
+    app.hooks.trashStatus.addClass('hide');
+    app.hooks.trashPanel.removeClass('hide');
+    app.hooks.serviceAreaStatus.addClass('hide');
+    app.hooks.serviceAreaPanel.removeClass('hide');
   }
 
   function renderError () {

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -311,6 +311,10 @@ app.views.property = function (accountNumber) {
 
     // Update the Tablesaw responsive tables
     $(document).trigger('enhance.tablesaw');
+    
+    // Hide status, show content.
+    app.hooks.valuationStatus.hide();
+    app.hooks.valuationPanel.show();
   }
 
   function getExteriorConditionDescription(id) {
@@ -391,6 +395,12 @@ app.views.property = function (accountNumber) {
     app.hooks.pwdPressure.text(sa.pwd_pres_dist);
     app.hooks.waterTreatment.text(sa.pwd_wtpsa);
     app.hooks.waterPlate.text(sa.water_plate);
+    
+    // Hide status messages, load content.
+    app.hooks.serviceAreaStatus.hide();
+    app.hooks.serviceAreaPanel.show();
+    app.hooks.trashStatus.hide();
+    app.hooks.trashPanel.show();
   }
 
   function renderError () {


### PR DESCRIPTION
Adds spinners to valuation history and service area panels. Also defaults `Homestead Exemption` to blank instead of Yes, per user feedback.

Closes #129 
