### PR TITLE
Add information about the map tiles not being from DOR

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,6 +25,11 @@ body {
 .map {
   height: 200px;
 }
+.map-explainer p {
+  line-height: 1.2;
+  margin-top: 0.8rem;
+  margin-bottom: 0.8rem;
+}
 .front {
   margin-top: 1.6rem;
 }

--- a/index.html
+++ b/index.html
@@ -311,6 +311,7 @@
               <div class="text-right">
                 <a data-hook="street-view-url" href="#" class="small-text external" target="_blank">See in Google Street View</a>
               </div>
+              <div class="map-explainer"><p><small>These maps are created using data that may not represent the precise legal boundaries of each parcel. If you need access to the legal descriptions as they are contained in deeds, please refer to the Department of Records's <a href="https://secure.phila.gov/parcelexplorerauth/">Parcel Explorer</a>.</small></p></div>
             </div>
           </div>
           <div class="row">


### PR DESCRIPTION
Information explains that tiles are generated with non-DOR data, and points people to Parcel Explorer
![image](https://cloud.githubusercontent.com/assets/146749/14929220/738b0ac2-0e2a-11e6-9a4e-e65e95970155.png)
