### PR TITLE
Add Raven library directly to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
     <link rel="stylesheet" href="//cityofphiladelphia.github.io/patterns/dist/1.2.1/css/patterns.css">
     <link rel="stylesheet" href="css/style.css">
     <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
+
+
   </head>
   <body>
     <!-- Google Tag Manager [phila.gov] -->
@@ -43,6 +45,9 @@
       '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-MC6CR2');</script>
     <!-- End Google Tag Manager -->
+
+    <!-- Raven: the Sentry messaging library -->
+    <script src="https://cdn.ravenjs.com/3.0.1/raven.min.js"></script>
 
     <!--[if lte IE 8]>
       <p class="browsehappy alert">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
@@ -621,7 +626,14 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/6.1.2/foundation.min.js"></script>
     <script src="//cityofphiladelphia.github.io/patterns/dist/1.2.1/js/patterns.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/accounting.js/0.4.1/accounting.min.js"></script>
-    <script src="//js.arcgis.com/3.15/"></script>
+    
+    <!-- Use defer below so that the ArcGIS library loads after the page is
+         completely parsed.
+         https://geonet.esri.com/message/448542#comment-469973
+         https://github.com/Esri/angular-esri-map/issues/38#issuecomment-91439901
+    -->
+    <script src="//js.arcgis.com/3.15/" defer></script>
+    
     <script src="//maps.googleapis.com/maps/api/js?v=3&libraries=geometry"></script>
     <script src="js/deparam.js"></script>
     <script src="js/app.js"></script>


### PR DESCRIPTION
Due to some funny business with arcgis's use of dojo, we can't load Raven (the Sentry library) after we load the arcgis library, and thus can't load Raven with GTM. Doing so consistently results in `multipleDefine` errors (search "`multipleDefine`" at https://dojotoolkit.org/reference-guide/1.8/loader/amd.html).

For more information, see:
- https://geonet.esri.com/message/448542#comment-469973
- https://github.com/Esri/angular-esri-map/issues/38#issuecomment-91439901
