### PR TITLE
Close search-select-options dropdown if user clicks away

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,6 +4,9 @@ body {
   overflow-x:hidden;
 }
 
+.search {
+  z-index:32;
+}
 .search-head .small-text {
   margin-top: -20px;
 }
@@ -80,7 +83,6 @@ body {
   left: 0;
   top: 2.85714rem;
   min-width: 250px;
-  z-index: 31;
 }
 .search-select-options li {
   height: 2.85714rem;
@@ -109,6 +111,14 @@ body {
 .search-select-options small {
   color: #9299A5;
   font-style: italic;
+}
+.search-select-close{
+  width:100%;
+  height:100%;
+  position: absolute;
+  bottom: 0;
+  left:0;
+  z-index:31;
 }
 .search .field-lg {
   width: 65%;

--- a/css/style.css
+++ b/css/style.css
@@ -115,7 +115,7 @@ body {
 .search-select-close{
   width:100%;
   height:100%;
-  position: absolute;
+  position: fixed;
   bottom: 0;
   left:0;
   z-index:31;

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
               <div data-swiftype-index="false" class="large-24 columns">
                 <nav>
                   <ul data-hook="crumbs" class="breadcrumbs">
-                    <li><a href="/">alpha.phila.gov</a></li>
+                    <li><a href="http://alpha.phila.gov">alpha.phila.gov</a></li>
                     <li>Property</li>
                   </ul>
                 </nav>
@@ -154,6 +154,7 @@
                 </form>
               </div>
             </div>
+            <div data-hook="search-select-close" class="search-select-close hide"></div>
 
           </div>
           <div data-hook="search-left" class="medium-4 columns">&nbsp;</div>
@@ -626,14 +627,14 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/6.1.2/foundation.min.js"></script>
     <script src="//cityofphiladelphia.github.io/patterns/dist/1.2.1/js/patterns.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/accounting.js/0.4.1/accounting.min.js"></script>
-    
+
     <!-- Use defer below so that the ArcGIS library loads after the page is
          completely parsed.
          https://geonet.esri.com/message/448542#comment-469973
          https://github.com/Esri/angular-esri-map/issues/38#issuecomment-91439901
     -->
     <script src="//js.arcgis.com/3.15/" defer></script>
-    
+
     <script src="//maps.googleapis.com/maps/api/js?v=3&libraries=geometry"></script>
     <script src="js/deparam.js"></script>
     <script src="js/app.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -76,8 +76,8 @@ app.hooks.searchSelectClose.on('click', function(e) {
 });
 $('.search-form-option').on('click', function(e) {
   if ( !$('.search-select-close').hasClass('hide') ){
-    app.hooks.searchSelectOptions.toggleClass('hide');
-    app.hooks.searchSelectClose.toggleClass('hide');
+    app.hooks.searchSelectOptions.addClass('hide');
+    app.hooks.searchSelectClose.addClass('hide');
   }
 });
 

--- a/js/app.js
+++ b/js/app.js
@@ -66,6 +66,19 @@ app.hooks.appTitle.contents().wrap(app.hooks.frontLink);
 app.hooks.searchSelect.on('click', function(e) {
   e.preventDefault();
   app.hooks.searchSelectOptions.toggleClass('hide');
+  app.hooks.searchSelectClose.toggleClass('hide');
+});
+
+app.hooks.searchSelectClose.on('click', function(e) {
+  e.preventDefault();
+  app.hooks.searchSelectOptions.toggleClass('hide');
+  app.hooks.searchSelectClose.toggleClass('hide');
+});
+$('.search-form-option').on('click', function(e) {
+  if ( !$('.search-select-close').hasClass('hide') ){
+    app.hooks.searchSelectOptions.toggleClass('hide');
+    app.hooks.searchSelectClose.toggleClass('hide');
+  }
 });
 
 app.hooks.searchSelectOptions.find('li').on('click', function(e) {


### PR DESCRIPTION
This PR addresses two issues:
- The breadcrumb link for alpha.phila.gov was set to href="/" which is fine on alpha but the subdomain for property2 is property.phila.gov.
- The dropdown used to select the type of search being conducted remains open unless a user:
  - makes a selection from the dropdown's list of options
  - clicks the current option/initial dropdown

Note: `z-index` starts at 31 because the esri map contains elements that are set to `z-index:30`
