### PR TITLE
Render table labels in smallest responsive view

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@
       <div data-hook="no-results" class="columns">0 properties found</div>
       <div data-hook="results" class="columns results-view">
         <div data-hook="count" class="medium-6 columns" style="display:none"><span id="total"></span> properties found</div>
-        <table role="grid" summary="Property search results." class="tablesaw tablesaw-stack results no-borders" data-tablesaw-mode="stack">
+        <table role="grid" summary="Property search results." class="tablesaw tablesaw-stack results no-borders" data-tablesaw-mode="stack" data-hook="results-table">
           <thead>
             <tr>
               <th scope="col">Address</th>

--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@
         <div data-hook="valuation-status"><i class="fa fa-spinner fa-lg spin"></i> Loading...</div>
         <div data-hook="valuation-panel" class="row hide">
           <div class="columns">
-            <table role="grid" summary="Property valuation history." class="tablesaw tablesaw-stack" data-tablesaw-mode="stack">
+            <table role="grid" summary="Property valuation history." class="tablesaw tablesaw-stack" data-tablesaw-mode="stack" data-hook='valuation-table'>
               <thead>
                 <tr>
                   <th scope="col">Year</th>

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -416,8 +416,6 @@ app.views.property = function (accountNumber) {
         // TODO show warning
         // console.warn('Error getting valuation history');
       });
-      // Update the Tablesaw responsive tables
-      $(document).trigger('enhance.tablesaw');
     // Render sales info
     app.hooks.salesPrice.text(accounting.formatMoney(state.opa.sale_price));
     var saleDateMoment = moment(state.opa.sale_date),

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -404,6 +404,9 @@ app.views.property = function (accountNumber) {
           row.append($('<td>').text(accounting.formatMoney(vh.exempt_building)));
           app.hooks.valuation.append(row);
         });
+        // Reset Tablesaw Data
+        $('[data-hook="valuation"]').parent('table').table().data("table").destroy();
+        $('[data-hook="valuation"]').parent('table').table().data("table").refresh();
       })
       .fail(function () {
         // TODO show warning

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -18,6 +18,7 @@ app.views.property = function (accountNumber) {
   app.hooks.searchBox.removeClass('medium-16').addClass('medium-10 float-right');
 
   // Clear existing elements out of the way
+  app.hooks.valuationTable.detach();
   app.hooks.content.children().detach();
   app.hooks.aboveContent.children().detach();
 
@@ -404,15 +405,19 @@ app.views.property = function (accountNumber) {
           row.append($('<td>').text(accounting.formatMoney(vh.exempt_building)));
           app.hooks.valuation.append(row);
         });
-        // Reset Tablesaw Data
-        $('[data-hook="valuation"]').parent('table').table().data("table").destroy();
-        $('[data-hook="valuation"]').parent('table').table().data("table").refresh();
+
+        app.hooks.valuationTable.append(app.hooks.valuation);
+        app.hooks.valuationPanel.append(app.hooks.valuationTable);
+        // Update the Tablesaw responsive tables
+        $(document).trigger('enhance.tablesaw');
+
       })
       .fail(function () {
         // TODO show warning
         // console.warn('Error getting valuation history');
       });
-
+      // Update the Tablesaw responsive tables
+      $(document).trigger('enhance.tablesaw');
     // Render sales info
     app.hooks.salesPrice.text(accounting.formatMoney(state.opa.sale_price));
     var saleDateMoment = moment(state.opa.sale_date),

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -416,6 +416,7 @@ app.views.property = function (accountNumber) {
         // TODO show warning
         // console.warn('Error getting valuation history');
       });
+
     // Render sales info
     app.hooks.salesPrice.text(accounting.formatMoney(state.opa.sale_price));
     var saleDateMoment = moment(state.opa.sale_date),
@@ -432,9 +433,6 @@ app.views.property = function (accountNumber) {
     // app.hooks.homestead.text(state.opa.characteristics.homestead ? 'Yes' : 'No');
 
     opaDetailsRendered = true;
-
-    // Update the Tablesaw responsive tables
-    $(document).trigger('enhance.tablesaw');
 
     // Hide status, show content.
     app.hooks.valuationStatus.addClass('hide');

--- a/js/views/results.js
+++ b/js/views/results.js
@@ -59,7 +59,7 @@ app.views.results = function (parsedQuery) {
     app.hooks.content.append(app.hooks.loading);
     getData()
   }
-  
+
   function getData () {
     var params = {
       gatekeeperKey: app.config['gatekeeperKey'],
@@ -73,7 +73,7 @@ app.views.results = function (parsedQuery) {
         var property, accountNumber, href, withUnit;
 
         if (!app.globals.historyState) history.state = {};
-        
+
         // For business reasons, owner searches need to always show on the
         // results page for the disclaimer.
         if (!isOwnerSearch && (
@@ -108,7 +108,7 @@ app.views.results = function (parsedQuery) {
               aisData = $.extend({isOwnerSearch: true}, aisData);
             }
             newState = aisData
-  
+
             if (!app.globals.historyState) {
               history.state = newState;
             } else {
@@ -123,7 +123,7 @@ app.views.results = function (parsedQuery) {
         render();
       });
   }
-  
+
   function constructOpaUrl (features) {
     var accountNumbers = $.map(features, function (feature) {
       return feature.properties.opa_account_num
@@ -140,7 +140,7 @@ app.views.results = function (parsedQuery) {
     };
     return '//data.phila.gov/resource/tqtk-pmbv.json?' + $.param(params)
   }
-  
+
   function keyBy (items, key) {
     var hash = {}
     for (var i = 0; i < items.length; i++) {
@@ -155,7 +155,7 @@ app.views.results = function (parsedQuery) {
     var features = state.features;
     var total_size = state.total_size;
     var isOwnerSearch = state.isOwnerSearch;
-    
+
     app.hooks.content.empty(); // Remove loading message
 
     if (total_size === 0) {
@@ -177,14 +177,14 @@ app.views.results = function (parsedQuery) {
         var seeMoreA = app.hooks.seeMore.find('a');
         seeMoreA.off('click'); // Drop previously created click events
         seeMoreA.on('click', function (e) {
-          
+
           var params = {
             gatekeeperKey: app.config['gatekeeperKey'],
             include_units: null,
             opa_only: null,
             page: state.page + 1
           };
-  
+
           $.ajax('https://api.phila.gov/ais/v1/' + endpoint,
                  {data: params, dataType: app.settings.ajaxType})
             .done(function (aisData) {
@@ -200,12 +200,13 @@ app.views.results = function (parsedQuery) {
                 state.features = state.features.concat(aisData.features);
                 state.page = aisData.page;
                 history.replaceState(state, ''); // Second param not optional in IE10
-  
+
                 $.each(aisData.features, addRow);
                 if (state.total_size === state.features.length) app.hooks.seeMore.hide();
-  
-                // Update the Tablesaw responsive tables
-                $(document).trigger('enhance.tablesaw');
+
+                // Remove old Tablesaw data and refresh
+                $('[data-hook="results-table"]').table().data("table").destroy();
+                $('[data-hook="results-table"]').table().data("table").refresh();
               });
             });
         });
@@ -249,13 +250,13 @@ app.views.results = function (parsedQuery) {
         accountNumber = attrs.opa_account_num,
         withUnit = attrs.street_address,
         href = '?' + $.param({p: accountNumber});
-        
+
     row.append($('<td>').append($('<a href="' + href + '">').text(withUnit)));
     row.append($('<td>').text(accounting.formatMoney(attrs.market_value)));
     row.append($('<td>').text(moment(attrs.sale_date).format('M/D/YYYY') + ', ' + accounting.formatMoney(attrs.sale_price)));
     row.append($('<td>').text(attrs.opa_owners && attrs.opa_owners.join(', ')));
     row.append($('<td class="hide-for-small-only">').html('<i class="fa fa-arrow-circle-right"></i>'));
-    
+
     row.on('click', function (e) {
         if (e.ctrlKey || e.altKey || e.shiftKey) return;
         e.preventDefault();


### PR DESCRIPTION
Append the Valuation History panel only after the data rows have been appended. Then, trigger Tablesaw to properly add the appropriate labels to the `td` elements.

Closes #148 
