### PR TITLE
Set default map zoom to 18

### DIFF
--- a/js/views/property.js
+++ b/js/views/property.js
@@ -181,7 +181,7 @@ app.views.property = function (accountNumber) {
           app.globals.map.disableScrollWheelZoom();
 
           // Set center
-          app.globals.map.centerAndZoom([state.opa.geometry.x, state.opa.geometry.y], 8);
+          app.globals.map.centerAndZoom([state.opa.geometry.x, state.opa.geometry.y], 18);
 
           // If check to fix intermittent bugs
           if (!app.globals.map || !app.globals.map.graphics) {


### PR DESCRIPTION
The basemap update changed the scale of the map. This sets the default zoom level to be more.

Demo at http://property-map-zoom.surge.sh/?p=883309000

@tswanson if this resolves the issue please merge.
