### PR TITLE
Various accessibility improvements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -36,7 +36,8 @@ body {
 .front {
   margin-top: 1.6rem;
 }
-.panel h4{
+.panel h4,
+.panel .h4{
   color:#666;
   margin-bottom: 0;
 }

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/index.html
+++ b/index.html
@@ -121,27 +121,33 @@
                 <div data-hook="search-form-container" class="float-left search-form-container">
                   <!-- Address -->
                   <form data-hook="search-address" class="search-form-option">
-                    <input type="text" class="float-left field-lg" data-hook="search-address" name="a" placeholder="1234 Market St">
-                    <input type="text" class="float-left field-sm" data-hook="search-unit" name="u" placeholder="Unit #">
+                    <label for="search-address" class="show-for-sr">Search by block</label>
+                    <input id="search-address" type="text" class="float-left field-lg" data-hook="search-address" name="a" placeholder="1234 Market St">
+                    <label for="search-unit" class="show-for-sr">Unit number</label>
+                    <input id="search-unit" type="text" class="float-left field-sm" data-hook="search-unit" name="u" placeholder="Unit #">
                     <input type="submit" value="submit">
                   </form>
 
                   <!-- Block -->
                   <form data-hook="search-block" class="search-form-option hide">
-                    <input type="text" class="float-left field-sm" data-hook="search-blocknum" name="bn" placeholder="1200">
-                    <input type="text" class="float-left field-lg" data-hook="search-blockstreet" name="bs" placeholder="Market St">
+                    <label for="search-blocknum" class="show-for-sr">Block number</label>
+                    <input id="search-blocknum" type="text" class="float-left field-sm" data-hook="search-blocknum" name="bn" placeholder="1200">
+                    <label for="search-blockstreet" class="show-for-sr">Block street</label>
+                    <input id="search-blockstreet" type="text" class="float-left field-lg" data-hook="search-blockstreet" name="bs" placeholder="Market St">
                     <input type="submit" value="submit">
                   </form>
 
                   <!-- Owner -->
                   <form data-hook="search-owner" class="search-form-option hide">
-                    <input type="text" class="float-left" name="o" placeholder="Doe John">
+                    <label for="search-owner" class="show-for-sr">Search by owner</label>
+                    <input id="search-owner" type="text" class="float-left" name="o" placeholder="Doe John">
                     <input type="submit" value="submit">
                   </form>
 
                   <!-- Account -->
                   <form data-hook="search-account" class="search-form-option hide">
-                    <input type="text" class="float-left" name="an" placeholder="883309000">
+                    <label for="search-account" class="show-for-sr">Search by account number</label>
+                    <input id="search-account" type="text" class="float-left" name="an" placeholder="883309000">
                     <input type="submit" value="submit">
                   </form>
 
@@ -223,7 +229,7 @@
 
     <!-- End Footer -->
     <div id="terms-modal" class="reveal" data-reveal aria-labelledby="modal-title" aria-hidden="true" role="dialog">
-      <h3>Terms of Use</h3>
+      <h3 id="modal-title">Terms of Use</h3>
       <p>The Office of Property Assessment of the City of Philadelphia (OPA) makes every effort to produce and publish on this site the most accurate and current information available to it. Our ownership records are based on deeds as recorded with the City of Philadelphia Department of Records (DOR), and we revise these records for currency as often as we are able. You are responsible, however, for verifying the accuracy of the information on this site by referring to the corresponding deed(s).</p>
       <p>The OPA is not an abstract company and we do not determine who has the better title to a property if the public records conflict as to ownership. The information on this site is not intended to indicate the quality of title or priority of interest in any property, and you are advised not to rely on it for that purpose.</p>
       <p>The market values and assessed values published on this site may not reflect changes made since the last update in our database. We do not have any information as to whether taxes have been paid for any particular property.</p>

--- a/index.html
+++ b/index.html
@@ -229,25 +229,25 @@
 
     <!-- End Footer -->
     <div id="terms-modal" class="reveal" data-reveal aria-labelledby="modal-title" aria-hidden="true" role="dialog">
-      <h3 id="modal-title">Terms of Use</h3>
+      <h1 id="modal-title" class="h3">Terms of Use</h1>
       <p>The Office of Property Assessment of the City of Philadelphia (OPA) makes every effort to produce and publish on this site the most accurate and current information available to it. Our ownership records are based on deeds as recorded with the City of Philadelphia Department of Records (DOR), and we revise these records for currency as often as we are able. You are responsible, however, for verifying the accuracy of the information on this site by referring to the corresponding deed(s).</p>
       <p>The OPA is not an abstract company and we do not determine who has the better title to a property if the public records conflict as to ownership. The information on this site is not intended to indicate the quality of title or priority of interest in any property, and you are advised not to rely on it for that purpose.</p>
       <p>The market values and assessed values published on this site may not reflect changes made since the last update in our database. We do not have any information as to whether taxes have been paid for any particular property.</p>
       <p>The additional City of Philadelphia terms and conditions below all apply to the information on this OPA site and to your access to and use of this information and the site.</p>
 
-      <h3>Disclaimer</h3>
+      <h2 class="h4">Disclaimer</h2>
       <p>The City of Philadelphia and the OPA (collectively, the City) make no warranty or representation whatsoever, express or implied, with respect to the quality, content, accuracy, completeness, currency, freedom from computer virus, suitability for any particular purpose, or non-infringement of proprietary rights, of any of the information published on this site, or any of the design, text, graphics, images, pages, interfaces, links, software, or other materials, documents, and items contained in or displayed or published on this site. All such items and materials are provided on an 'as is' basis, and you are fully and solely responsible for your use of them and for any results or consequences of your use. In many cases, they have been compiled from a variety of sources, including sources beyond the control of the City of Philadelphia, and are subject to change without notice from the City. Except as stated below, commercial use (including but not limited to sale to others) is prohibited without the prior written permission of the City. To the extent you use, apply, or implement this information in your own information system or other setting, or otherwise for your own purposes, you do so at your own risk. In no event shall the City, the OPA, the City's other agencies, or the officers, employees, agents, or representatives of any of the foregoing be liable for any direct, indirect, special, punitive, incidental, exemplary or consequential damages arising your accessing or using the site or any information displayed on the site, or otherwise arising from the site or from anything contained in or displayed on the site. Nothing contained in or displayed on this site constitutes or is intended to constitute legal advice by the City or any of its agencies, officers, employees, agents, attorneys, or representatives.</p>
 
-      <h3>External sites</h3>
+      <h2 class="h4">External sites</h2>
       <p>This site may contain links to other sites on the Internet that are operated by parties other than the City and have information that may be of interest to our users. The City has no control over these sites and is not responsible for their content or for the availability of the sites or their content. Our links to these sites are not an endorsement or recommendation of the sites or of any commercial or other products or services that may be advertised or available on them; nor does the City necessarily support the views or facts presented on them. Questions and concerns regarding the content of any linked external site should be addressed directly to the administrator of the external site.</p>
 
-      <h3>Copyright, trademarks and servicemarks</h3>
+      <h2 class="h4">Copyright, trademarks and servicemarks</h2>
       <p>Servicemarks and trademarks contained in or displayed on the site, and the contents of linked sites operated by third parties, are the property of their respective owners. All other design, information, text, graphics, images, pages, interfaces, links, software, and other items and materials contained in or displayed on this site, and the selection and arrangements thereof, are the property of the City of Philadelphia. All rights are reserved. Permission to copy electronically and to print information from the site is for personal use only, or to be shared with other persons on the condition that all information copied, printed, and/or shared is without cost to the recipients and exactly as printed on the site, without any addition or modification.</p>
 
-      <h3>Communications through the site</h3>
+      <h2 class="h4">Communications through the site</h2>
       <p>In no event shall any communication made through the e-mail, messaging or other communications functions of any City web site constitute legal or other notice to the City, the OPA, any of the City's other agencies, or to any of the officers, employees, agents, or representatives of the OPA or the City, including but not limited to (i) legal notice required by federal, state, or local laws, rules, or regulations with respect to any existing or potential claim or cause of action against the City or any of its agencies, officers, employees, agents, or representatives; (ii) any form of notice required pursuant to the OPA's regulations or policies or any federal, state, or local law applying to the OPA; or (iii) any form of notice required pursuant to any document issued by the OPA.</p>
 
-      <h3>Miscellaneous</h3>
+      <h2 class="h4">Miscellaneous</h2>
       <p>The foregoing terms and conditions and all disputes arising under them shall be governed, construed and decided in accordance with the laws of the Commonwealth of Pennsylvania. The City reserves the right to revise and otherwise change the foregoing terms and conditions at anytime and without notice. Headings are for convenience only and in no way define, limit, extend or describe the intent of any provision of these Terms of Use and Disclaimer.</p>
 
       <button class="close-button" data-close aria-label="Close" type="button">&#215;</button>
@@ -397,7 +397,7 @@
             <h1 data-hook="property-owners" class="no-margin owners"></h1>
           </div>
           <div class="medium-9 columns">
-            <h4 data-hook="property-mailing-header" class="alternate no-margin">Mailing Address</h4>
+            <h2 data-hook="property-mailing-header" class="h4 alternate no-margin">Mailing Address</h2>
             <div data-hook="property-mailing" class="bold mailing"></div>
           </div>
         </div> <!-- End owners -->
@@ -447,7 +447,7 @@
             <div class="panel sales mbm">
               <div class="row">
                 <div class="medium-12 columns">
-                  <h4 class="alternate">Sales Price</h4>
+                  <h3 class="h4 alternate">Sales Price</h3>
                   <strong data-hook="sales-price" class="stat"></strong>
                 </div>
                 <div class="medium-12 columns">
@@ -486,7 +486,7 @@
             <div class="panel sales mbm">
               <div class="row">
                 <div class="medium-12 columns">
-                  <h4 class="alternate">Trash &amp; Recycling Day</h4>
+                  <h3 class="h4 alternate">Trash &amp; Recycling Day</h3>
                   <strong data-hook="rubbish-day" class="stat no-margin"></strong>
                 </div>
                 <div class="medium-12 columns">

--- a/index.html
+++ b/index.html
@@ -124,33 +124,33 @@
                 <form data-hook="search-address" class="search-form-option">
                   <input type="text" class="float-left field-lg" data-hook="search-address" name="a" placeholder="1234 Market St">
                   <input type="text" class="float-left field-sm" data-hook="search-unit" name="u" placeholder="Unit #">
-                  <input type="submit">
+                  <input type="submit" value="submit">
                 </form>
 
                 <!-- Block -->
                 <form data-hook="search-block" class="search-form-option hide">
                   <input type="text" class="float-left field-sm" data-hook="search-blocknum" name="bn" placeholder="1200">
                   <input type="text" class="float-left field-lg" data-hook="search-blockstreet" name="bs" placeholder="Market St">
-                  <input type="submit">
+                  <input type="submit" value="submit">
                 </form>
 
                 <!-- Owner -->
                 <form data-hook="search-owner" class="search-form-option hide">
                   <input type="text" class="float-left" name="o" placeholder="Doe John">
-                  <input type="submit">
+                  <input type="submit" value="submit">
                 </form>
 
                 <!-- Account -->
                 <form data-hook="search-account" class="search-form-option hide">
                   <input type="text" class="float-left" name="an" placeholder="883309000">
-                  <input type="submit">
+                  <input type="submit" value="submit">
                 </form>
 
                 <!-- Intersection -->
                 <!-- <form data-hook="search-intersection" class="search-form-option hide">
                   <input type="text" class="float-left field-md" data-hook="search-int-street1" name="s1" placeholder="12th St">
                   <input type="text" class="float-left field-md" data-hook="search-int-street2" name="s2" placeholder="Market St">
-                  <input type="submit">
+                  <input type="submit" value="submit">
                 </form> -->
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
     <![endif]-->
 
     <div id="application" class="page">
+      <a class="skip-link screen-reader-text" href="#maincontent">Skip to content</a>
       <div data-swiftype-index="false" id="alpha-alert">
         <div class="row">
           <div class="large-18 columns">
@@ -81,8 +82,6 @@
               <h1 data-hook="app-title" class="page-title">Property</h1>
             </div>
           </div>
-
-          <a class="skip-link screen-reader-text" href="#content">Skip to content</a>
         </div>
         <div class="row expanded">
           <div class="columns">
@@ -99,79 +98,79 @@
           </div>
         </div>
       </header>
+      <main id="maincontent">
+        <div data-hook="above-content" class="row"></div>
+        <div class="search-head">
+          <div class="row">
+            <div data-hook="search-right" class="medium-4 columns">&nbsp;</div>
+            <div data-hook="search-box" class="search-box medium-16 columns">
 
-      <div data-hook="above-content" class="row"></div>
-      <div class="search-head">
-        <div class="row">
-          <div data-hook="search-right" class="medium-4 columns">&nbsp;</div>
-          <div data-hook="search-box" class="search-box medium-16 columns">
+              <div class="search">
+                <div class="search-select float-left" data-hook="search-select">
+                  <strong data-hook="search-select-label" class="float-left">Address</strong> <i class="fa fa-caret-down fa-lg"></i>
 
-            <div class="search">
-              <div class="search-select float-left" data-hook="search-select">
-                <strong data-hook="search-select-label" class="float-left">Address</strong> <i class="fa fa-caret-down fa-lg"></i>
+                  <ul class="search-select-options no-bullet hide" data-hook="search-select-options">
+                    <li data-searchtype="address"><label>Address</label> <small>1234 Market St</small></li>
+                    <li data-searchtype="block"><label>Block</label> <small>1200 Market St</small></li>
+                    <li data-searchtype="owner"><label>Owner</label> <small>Doe John</small></li>
+                    <li data-searchtype="account"><label>Account</label> <small>883309000</small></li>
+                    <!-- <li data-searchtype="intersection"><label>Intersection</label> <small>12th &amp; Market</small></li> -->
+                  </ul>
+                </div>
 
-                <ul class="search-select-options no-bullet hide" data-hook="search-select-options">
-                  <li data-searchtype="address"><label>Address</label> <small>1234 Market St</small></li>
-                  <li data-searchtype="block"><label>Block</label> <small>1200 Market St</small></li>
-                  <li data-searchtype="owner"><label>Owner</label> <small>Doe John</small></li>
-                  <li data-searchtype="account"><label>Account</label> <small>883309000</small></li>
-                  <!-- <li data-searchtype="intersection"><label>Intersection</label> <small>12th &amp; Market</small></li> -->
-                </ul>
+                <div data-hook="search-form-container" class="float-left search-form-container">
+                  <!-- Address -->
+                  <form data-hook="search-address" class="search-form-option">
+                    <input type="text" class="float-left field-lg" data-hook="search-address" name="a" placeholder="1234 Market St">
+                    <input type="text" class="float-left field-sm" data-hook="search-unit" name="u" placeholder="Unit #">
+                    <input type="submit" value="submit">
+                  </form>
+
+                  <!-- Block -->
+                  <form data-hook="search-block" class="search-form-option hide">
+                    <input type="text" class="float-left field-sm" data-hook="search-blocknum" name="bn" placeholder="1200">
+                    <input type="text" class="float-left field-lg" data-hook="search-blockstreet" name="bs" placeholder="Market St">
+                    <input type="submit" value="submit">
+                  </form>
+
+                  <!-- Owner -->
+                  <form data-hook="search-owner" class="search-form-option hide">
+                    <input type="text" class="float-left" name="o" placeholder="Doe John">
+                    <input type="submit" value="submit">
+                  </form>
+
+                  <!-- Account -->
+                  <form data-hook="search-account" class="search-form-option hide">
+                    <input type="text" class="float-left" name="an" placeholder="883309000">
+                    <input type="submit" value="submit">
+                  </form>
+
+                  <!-- Intersection -->
+                  <!-- <form data-hook="search-intersection" class="search-form-option hide">
+                    <input type="text" class="float-left field-md" data-hook="search-int-street1" name="s1" placeholder="12th St">
+                    <input type="text" class="float-left field-md" data-hook="search-int-street2" name="s2" placeholder="Market St">
+                    <input type="submit" value="submit">
+                  </form> -->
+                </div>
               </div>
+              <div data-hook="search-select-close" class="search-select-close hide"></div>
 
-              <div data-hook="search-form-container" class="float-left search-form-container">
-                <!-- Address -->
-                <form data-hook="search-address" class="search-form-option">
-                  <input type="text" class="float-left field-lg" data-hook="search-address" name="a" placeholder="1234 Market St">
-                  <input type="text" class="float-left field-sm" data-hook="search-unit" name="u" placeholder="Unit #">
-                  <input type="submit" value="submit">
-                </form>
-
-                <!-- Block -->
-                <form data-hook="search-block" class="search-form-option hide">
-                  <input type="text" class="float-left field-sm" data-hook="search-blocknum" name="bn" placeholder="1200">
-                  <input type="text" class="float-left field-lg" data-hook="search-blockstreet" name="bs" placeholder="Market St">
-                  <input type="submit" value="submit">
-                </form>
-
-                <!-- Owner -->
-                <form data-hook="search-owner" class="search-form-option hide">
-                  <input type="text" class="float-left" name="o" placeholder="Doe John">
-                  <input type="submit" value="submit">
-                </form>
-
-                <!-- Account -->
-                <form data-hook="search-account" class="search-form-option hide">
-                  <input type="text" class="float-left" name="an" placeholder="883309000">
-                  <input type="submit" value="submit">
-                </form>
-
-                <!-- Intersection -->
-                <!-- <form data-hook="search-intersection" class="search-form-option hide">
-                  <input type="text" class="float-left field-md" data-hook="search-int-street1" name="s1" placeholder="12th St">
-                  <input type="text" class="float-left field-md" data-hook="search-int-street2" name="s2" placeholder="Market St">
-                  <input type="submit" value="submit">
-                </form> -->
-              </div>
             </div>
-            <div data-hook="search-select-close" class="search-select-close hide"></div>
-
+            <div data-hook="search-left" class="medium-4 columns">&nbsp;</div>
           </div>
-          <div data-hook="search-left" class="medium-4 columns">&nbsp;</div>
-        </div>
-        <div data-hook="owner-search-disclaimer" class="row hide">
-          <div class="small-24 columns">
-            <p class="center mtm mbn">
-              Your IP address is <strong data-hook="owner-search-disclaimer-ip" data-default="170.115.248.21">(<i class="fa fa-spinner fa-lg spin"></i> Loading)</strong> and you searched for properties owned by <strong data-hook="owner-search-disclaimer-query">(<i class="fa fa-spinner fa-lg spin"></i> Loading)</strong> on <span data-hook="owner-search-disclaimer-datetime"></span>.
-              <span data-tooltip aria-haspopup="true" class="has-tip" title="Property owner searches are recorded to encourage safe and responsible use. The data shown here represents your visit to this page."><i class="fa fa-info-circle"></i></span>
-            </p>
+          <div data-hook="owner-search-disclaimer" class="row hide">
+            <div class="small-24 columns">
+              <p class="center mtm mbn">
+                Your IP address is <strong data-hook="owner-search-disclaimer-ip" data-default="170.115.248.21">(<i class="fa fa-spinner fa-lg spin"></i> Loading)</strong> and you searched for properties owned by <strong data-hook="owner-search-disclaimer-query">(<i class="fa fa-spinner fa-lg spin"></i> Loading)</strong> on <span data-hook="owner-search-disclaimer-datetime"></span>.
+                <span data-tooltip aria-haspopup="true" class="has-tip" title="Property owner searches are recorded to encourage safe and responsible use. The data shown here represents your visit to this page."><i class="fa fa-info-circle"></i></span>
+              </p>
+            </div>
           </div>
         </div>
+        <div data-hook="content" class="row"></div>
+        <div data-hook="below-content" class="row"></div>
       </div>
-      <div data-hook="content" class="row"></div>
-      <div data-hook="below-content" class="row"></div>
-    </div>
-
+    </main>
     <!-- Begin Footer -->
     <div class="row feedback">
       <div class="small-24 columns">

--- a/index.html
+++ b/index.html
@@ -74,8 +74,8 @@
       <header data-swiftype-index="false" id="masthead" class="site-header app" role="banner">
         <div class="row site-branding">
           <div class="small-24 columns">
-            <a href="http://alpha.phila.gov/" class="logo">
-              <img data-interchange="[//cityofphiladelphia.github.io/patterns/images/city-of-philadelphia-mobile.png, small], [//cityofphiladelphia.github.io/patterns/images/city-of-philadelphia-white.png, medium] ">
+            <a href="http://alpha.phila.gov/" class="logo" aria-label="Return to beta.phila.gov">
+              <img data-interchange="[//cityofphiladelphia.github.io/patterns/images/city-of-philadelphia-mobile.png, small], [//cityofphiladelphia.github.io/patterns/images/city-of-philadelphia-white.png, medium] " alt="phila.gov">
             </a>
             <div class="page-title-container">
               <h1 data-hook="app-title" class="page-title">Property</h1>


### PR DESCRIPTION
Closes #176 

Addresses the following items:
- [x] Document language missing ( add `lang="en"` to opening `html` element )
- [x] Linked logo image needs `alt` attribute. Typically this can be left as `alt=""` for decorative images however logos typically receive alt text . Consider giving the link an `aria-label`
- [x] The input fields are missing labels. Important for those visitors who use screen readers, these can be added without altering the look of the page by using the `show-for-sr` class
- [x] Submit button `input` elements require a `value`
- [x] Broken skip link
- [x] Broken `aria-labelledby` on ToS modal
- [x] Results pages have some heading order issues
