### PR TITLE
Link directly to tax balance for the account

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,8 +408,7 @@
         <div class="row">
           <div class="hide-for-print medium-14 columns"><p class="no-margin normal">Real Estate Tax account balances have not yet been added to this application.</p></div>
           <div class="medium-10 columns text-right">
-            <a class="button no-margin" href="http://www.phila.gov/revenue/realestatetax">View the Tax Balance</a>
-            <div class="small-text">On Department of Revenue website<br>Your <span title="Board of Revision of Taxes">BRT</span> Number is <strong data-hook="opa-account"></strong></div>
+            <a data-hook="tax-balance-link" class="button no-margin">View the Tax Balance</a>
           </div>
         </div> <!-- End taxes -->
         <div class="row"> <!-- Begin valuation -->

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -151,8 +151,6 @@ app.views.property = function (accountNumber) {
       if (owner) app.hooks.propertyOwners.append($('<div>').text(owner));
     });
 
-    app.hooks.opaAccount.text(state.opa.parcel_number);
-
     // Empty things that will be rendered form OPA details
     app.hooks.improvementDescription.empty();
     app.hooks.landArea.empty();
@@ -332,6 +330,10 @@ app.views.property = function (accountNumber) {
     pm.append($('<div>').text(mailing_street));
     pm.append($('<div>').text(mailing_city_state));
     pm.append($('<div>').text(mailing_zip));
+
+    // Update tax balance button with a direct link to the account
+    var taxBalanceUrl = 'http://www.phila.gov/revenue/realestatetax/?txtBRTNo=' + opa.parcel_number;
+    app.hooks.taxBalanceLink.attr('href', taxBalanceUrl);
 
     // Render zoning
     // TODO Socrata is missing zoning description


### PR DESCRIPTION
This PR updates the "View Tax Balance" button to link directly to the same account in the real estate tax app.

Also removes explanatory text about OPA vs. BRT account num which is no
longer needed. Closes #190 