### PR TITLE
Disable JSONP requests

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -13,7 +13,6 @@ window.app = app;
 
 // Config
 app.config = {
-  ajaxType:             $.support.cors ? 'json' : 'jsonp',
   gatekeeperKey:        'c0eb3e7795b0235dfed5492fcd12a344',
   initialMapZoomLevel:  18,
   defaultError:         'Failed to retrieve results. Please try another search.',

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -70,7 +70,6 @@ app.views.property = function (accountNumber) {
 
     $.ajax({
       url: url,
-      dataType: app.config.ajaxType,
       data: params,
     })
       .then(function (res) {
@@ -111,8 +110,10 @@ app.views.property = function (accountNumber) {
       // gatekeeperKey: app.config['gatekeeperKey'],
     };
 
-    $.ajax( 'https://api.phila.gov/ais_ps/v1/account/' + accountNumber,
-      {data: params, dataType: app.config.ajaxType})
+    $.ajax({
+      url: 'https://api.phila.gov/ais_ps/v1/account/' + accountNumber,
+      data: params
+    })
       .done(function (data) {
         var state = $.extend({}, history.state);
         var property, href, withUnit;


### PR DESCRIPTION
Currently if jQuery says the browser doesn't support CORS, it falls back to JSONP. The current APIs don't support this, so force JSON requests instead.