### PR TITLE
Reflect user input in 400 errors

### DIFF
--- a/js/views/property.js
+++ b/js/views/property.js
@@ -37,6 +37,7 @@ app.views.property = function (accountNumber) {
   if (!history.state) history.replaceState({}, '');
 
   // If there's an error, render it and stop there.
+  // REVIEW this doesn't seem to be used anymore
   if (history.state.error) {
     renderError(history.state.error);
     return;

--- a/js/views/results.js
+++ b/js/views/results.js
@@ -146,7 +146,9 @@ app.views.results = function (parsedQuery) {
 
     switch(status) {
       case 404:
-        message = "We couldn't find any results for <strong>" + queryType.toUpperCase() + ": " + queryParam + "</strong>. Please review your search and try again."
+        message = "We couldn't find any <strong>" + queryType +
+                  "</strong> results for <strong>" + queryParam +
+                  "</strong>. Please review your search and try again.";
         break;
       default:
         message = app.config.defaultError;

--- a/js/views/results.js
+++ b/js/views/results.js
@@ -40,7 +40,7 @@ app.views.results = function (parsedQuery) {
       queryParam = parsedQuery.address;
 
       if (parsedQuery.unit) {
-        queryParam = ' UNIT ' + parsedQuery.unit;
+        queryParam += ' UNIT ' + parsedQuery.unit;
       }
       break;
     case 'owner':

--- a/js/views/results.js
+++ b/js/views/results.js
@@ -69,14 +69,8 @@ app.views.results = function (parsedQuery) {
     $.ajax({
       url: 'https://api.phila.gov/ais_ps/v1/' + endpoint,
       data: params,
-      dataType: app.config.ajaxType,
       success: didGetAisData,
-      error: function (jqXHR, textStatus, errorThrown) {
-        console.debug('ais error', textStatus);
-        var error = app.config.defaultError;
-        history.replaceState({error: error}, '');
-        render();
-      },
+      error: didGetAisError,
     });
   }
 
@@ -138,6 +132,14 @@ app.views.results = function (parsedQuery) {
           render();
         });
     }
+  }
+
+  function didGetAisError(jqXHR, textStatus, errorThrown) {
+    console.debug('ais error', textStatus, errorThrown);
+
+    var error = app.config.defaultError;
+    history.replaceState({error: error}, '');
+    render();
   }
 
   function constructOpaUrl (features) {


### PR DESCRIPTION
Currently there's only error message displayed in Property: "Failed to retrieve results." This happens whether the issue is user-generated or coming from the backend.

This branch introduces a new message for user errors that reflects the search terms passed to AIS:

![image](https://cloud.githubusercontent.com/assets/1463553/26261833/c2b2b0c8-3ca0-11e7-8630-9f4e85298754.png)

Looking over `404` errors in Sentry, it seems fairly common for users to search using the wrong type, for instance Block instead of Address. This should help mitigate some of the confusion with the dropdown until there's a longer-term UI replacement (e.g. tabs).

Closes #119 