### PR TITLE
Reenable tax query and update Parcel Explorer link

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,11 +322,10 @@
                 <p>
                   <small>
                     These maps are created for reference only and do not
-                    represent precise legal boundaries. If you need access to
-                    the legal descriptions as they are contained in deeds,
-                    please visit
-                    <a href="http://epay.phila-records.com/phillyepay/web/" class="external" target="_blank">
-                      PhilaDox
+                    represent precise legal boundaries. For more information
+                    about deeds, please visit
+                    <a data-hook="atlas-link" href="https://atlas.phila.gov/" class="external" target="_blank">
+                      Atlas
                     </a>
                     .
                   </small>

--- a/index.html
+++ b/index.html
@@ -318,7 +318,20 @@
               <div class="text-right">
                 <a data-hook="street-view-url" href="#" class="small-text external" target="_blank">See in Google Street View</a>
               </div>
-              <div class="map-explainer"><p><small>These maps are created for reference only and do not represent precise legal boundaries. If you need access to the legal descriptions as they are contained in deeds, please refer to the Department of Records's <a href="https://secure.phila.gov/parcelexplorerauth/">Parcel Explorer</a>.</small></p></div>
+              <div class="map-explainer">
+                <p>
+                  <small>
+                    These maps are created for reference only and do not
+                    represent precise legal boundaries. If you need access to
+                    the legal descriptions as they are contained in deeds,
+                    please visit
+                    <a href="http://epay.phila-records.com/phillyepay/web/" class="external" target="_blank">
+                      PhilaDox
+                    </a>
+                    .
+                  </small>
+                </p>
+              </div>
             </div>
           </div>
           <div class="row">

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -368,8 +368,7 @@ app.views.property = function (accountNumber) {
     pm.append($('<div>').text(mailing_zip));
 
     // Update tax balance button with a direct link to the account
-    // var taxBalanceUrl = 'http://www.phila.gov/revenue/realestatetax/?txtBRTNo=' + opa.parcel_number;
-    var taxBalanceUrl = 'http://www.phila.gov/revenue/realestatetax/';
+    var taxBalanceUrl = 'http://www.phila.gov/revenue/realestatetax/?txtBRTNo=' + opa.parcel_number;
     app.hooks.taxBalanceLink.attr('href', taxBalanceUrl);
 
     // Render zoning

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -206,8 +206,15 @@ app.views.property = function (accountNumber) {
     }
     app.hooks.opaInquiryUrl.attr('href', 'http://opa.phila.gov/opa.apps/Help/CitizenMain.aspx?sch=Ctrl2&s=1&url=search&id=' + tencode);
 
+    // REVIEW this seems to work, but when you hover over the link in chrome
+    // it doesn't appear to be encoded.
+    var addressEncoded = encodeURIComponent(state.address);
+
     // Set L&I link
-    app.hooks.liLink.attr('href', 'http://li.phila.gov/#summary?address=' + encodeURI(state.address));
+    app.hooks.liLink.attr('href', 'http://li.phila.gov/#summary?address=' + addressEncoded);
+
+    // set atlas link
+    app.hooks.atlasLink.attr('href', 'https://atlas.phila.gov/#/' + addressEncoded + '/deeds');
 
     opaRendered = true;
   }


### PR DESCRIPTION
Links to PhilaDox instead of Parcel Explorer, which has been shut down.