### PR TITLE
Add tax calculator back, using new homestead values

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,9 +388,9 @@
         </div>
         <div class="row columns" style="margin-bottom: 10px">
           <p class="normal">
-            You can estimate the 2019 Real Estate Tax of this property based on the proposed tax rate and
+            You can estimate the 2019 Real Estate Tax of this property based on the tax rate and
             <a href="https://beta.phila.gov/services/property-lots-housing/get-the-homestead-exemption/">Homestead Exemption</a> amount.
-            The Homestead Exemption saves most taxpayers about $550 on their Real Estate Tax.
+            The Homestead Exemption will typically save homeowners about $550 on their Real Estate Tax.
             These estimates are for information only, and may not be the actual amount of Real Estate Tax for 2019.
           </p>
 

--- a/index.html
+++ b/index.html
@@ -390,21 +390,18 @@
           <p class="normal">
             You can estimate the 2019 Real Estate Tax of this property based on the proposed tax rate and
             <a href="https://beta.phila.gov/services/property-lots-housing/get-the-homestead-exemption/">Homestead Exemption</a> amount.
+            The Homestead Exemption saves most taxpayers about $550 on their Real Estate Tax.
             These estimates are for information only, and may not be the actual amount of Real Estate Tax for 2019.
           </p>
 
           <div class="row">
-            <div class="medium-8 columns">
+            <div class="medium-7 columns">
               <label for="rate">Tax rate</label>
-              <select id="rate" data-hook="tax-estimate-rate">
-                <option value="current">1.3998% (Current)</option>
-                <option value="proposed" selected>1.4572% (Proposed)</option>
-              </select>
+              <p>1.4572% (2019)</p>
             </div>
-            <div class="medium-8 columns">
-              <label>Homestead Exemption</label>
+            <div class="medium-9 columns">
               <input type="checkbox" id="homestead" data-hook="tax-estimate-homestead-checkbox">
-              <label for="homestead" data-hook="tax-estimate-homestead-label"></label>
+              <label for="homestead">Homestead Exemption</label>
               <div data-hook="homestead-disabled-tip"
                    data-tooltip title="It looks like your property already has an exemption that makes it ineligible for the Homestead Exemption."
                    class="has-tip"

--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@
           <div class="row">
             <div class="medium-7 columns">
               <label for="rate">Tax rate</label>
-              <p>1.4572% (2019)</p>
+              <p>1.3998% (2019)</p>
             </div>
             <div class="medium-9 columns">
               <input type="checkbox" id="homestead" data-hook="tax-estimate-homestead-checkbox">

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -433,6 +433,8 @@ app.views.property = function (accountNumber) {
       .prop('disabled', shouldDisableHomestead);
 
     app.hooks.homesteadDisabledTip.toggle(!alreadyHasHomestead && shouldDisableHomestead);
+    // call foundation again to activate the homestead disabled tooltip
+    $(app.hooks.homesteadDisabledTip).foundation();
 
     updateTaxEstimate();
 
@@ -443,6 +445,7 @@ app.views.property = function (accountNumber) {
       $(this).hide();
       app.hooks.taxEstimateResult.show();
     })
+
 
     // Render zoning
     // TODO Socrata is missing zoning description

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -402,7 +402,7 @@ app.views.property = function (accountNumber) {
         if (alreadyHasHomestead) {
           // calculate their current homestead proportionate to 30k and
           // apply to 40k
-          var proposedHomestead = existingHomesteadValue / 30000 * 40000;
+          var proposedHomestead = existingHomesteadValue / 40000 * 40000;
           // exemptValue += proposedHomestead;
           exemptValue = proposedHomestead;
         // if they don't already have a homestead, use 40k

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -386,10 +386,7 @@ app.views.property = function (accountNumber) {
       var marketValue = opa.market_value,
           exemptValue = opa.exempt_building + opa.exempt_land;
 
-      // get selected tax rate
-      var rateVal = app.hooks.taxEstimateRate.val(),
-          useProposed = rateVal === 'proposed',
-          rate = useProposed ? 1.4572 : 1.3998;
+      var rate = 1.4572;
 
       // get homestead checkbox value
       var homesteadCheckbox = app.hooks.taxEstimateHomesteadCheckbox,
@@ -401,23 +398,16 @@ app.views.property = function (accountNumber) {
 
       // handle homestead exemption if necessary
       if (isHomesteadChecked) {
-        // if we're using the proposed rate
-        if (useProposed) {
-          // and they already have an exemption
-          if (alreadyHasHomestead) {
-            // calculate their current homestead proportionate to 30k and
-            // apply to 45k
-            var proposedHomestead = existingHomesteadValue / 30000 * 45000;
-            // exemptValue += proposedHomestead;
-            exemptValue = proposedHomestead;
-          // if they don't already have a homestead, use 45k
-          } else {
-            exemptValue = 45000;
-          }
-        // if we're using the current rate
+        // if they already have an exemption
+        if (alreadyHasHomestead) {
+          // calculate their current homestead proportionate to 30k and
+          // apply to 40k
+          var proposedHomestead = existingHomesteadValue / 30000 * 40000;
+          // exemptValue += proposedHomestead;
+          exemptValue = proposedHomestead;
+        // if they don't already have a homestead, use 40k
         } else {
-          // use their existing homestead or the standard homestead of 30k
-          exemptValue = existingHomesteadValue || 30000;
+          exemptValue = 40000;
         }
       }
 
@@ -435,30 +425,6 @@ app.views.property = function (accountNumber) {
       app.hooks.taxEstimateResult.text(formattedTaxEstimate);
     }
 
-    function updateHomesteadLabel() {
-      // call foundation again to activate the homestead disabled tooltip
-      $(document).foundation();
-
-      var existingHomesteadValue = opa.homestead_exemption,
-          rateVal = app.hooks.taxEstimateRate.val(),
-          displayHomesteadValue;
-
-      // if they already have a homestead exemption, use that value
-      if (existingHomesteadValue > 0) {
-        if (rateVal === 'proposed') {
-          displayHomesteadValue = existingHomesteadValue / 30000 * 45000;
-        } else {
-          displayHomesteadValue = existingHomesteadValue;
-        }
-      // otherwise, use the value associated with the tax rate they selected
-      } else {
-        displayHomesteadValue = (rateVal === 'proposed') ? 45000 : 30000;
-      }
-
-      var newHomesteadLabel = accounting.formatMoney(displayHomesteadValue);
-      app.hooks.taxEstimateHomesteadLabel.text(newHomesteadLabel);
-    }
-
     var alreadyHasHomestead = (opa.homestead_exemption > 0);
     var hasExemptValue = opa.exempt_building + opa.exempt_land > 0;
     var shouldDisableHomestead = alreadyHasHomestead || hasExemptValue;
@@ -469,11 +435,6 @@ app.views.property = function (accountNumber) {
     app.hooks.homesteadDisabledTip.toggle(!alreadyHasHomestead && shouldDisableHomestead);
 
     updateTaxEstimate();
-    updateHomesteadLabel();
-
-    app.hooks.taxEstimateRate
-      .change(updateTaxEstimate)
-      .change(updateHomesteadLabel);
 
     app.hooks.taxEstimateHomesteadCheckbox
       .change(updateTaxEstimate);

--- a/js/views/property.js
+++ b/js/views/property.js
@@ -386,7 +386,7 @@ app.views.property = function (accountNumber) {
       var marketValue = opa.market_value,
           exemptValue = opa.exempt_building + opa.exempt_land;
 
-      var rate = 1.4572;
+      var rate = 1.3998;
 
       // get homestead checkbox value
       var homesteadCheckbox = app.hooks.taxEstimateHomesteadCheckbox,


### PR DESCRIPTION
Not ready to merge. Before merging this pull request:

1. OPA IT Director will review the [test site](http://property-2019-after-budget.surge.sh/) and verify
2. OPA, in consultation with CityGeo, will push the homestead data updates that were tested in BRTTEST into BRTPROD. AFAIK this should not break anything in production because the tax calculator is currently hidden in production.

FYI @regisshogan per ongoing email thread.